### PR TITLE
Remove "satRdays/" from file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git push --mirror https://github.com/satRdays/[cityYEAR].git
 
 ```
 cd ..
-rm -rf satRdays/satRday_site_template.git
+rm -rf satRday_site_template.git
 ```
 
 #### Customise the config


### PR DESCRIPTION
If you've followed the instructions up to this point, you're already in the working directory - I didn't need to have a "satRdays/" in the file path to remove the temporary .git file