### PR TITLE
Create tweetthis shortcode

### DIFF
--- a/layouts/shortcodes/tweetthis.html
+++ b/layouts/shortcodes/tweetthis.html
@@ -1,0 +1,6 @@
+<a class="twitter-share-button"
+  href="https://twitter.com/intent/tweet?text={{ .Get 0}}&hashtags={{ .Get 1 }}"
+  data-size="large" 
+  data-lang="en" 
+   data-show-count="false">
+Tweet this </a>


### PR DESCRIPTION
This is a very simple building block that allows us to create a tweet this anchor (link) with a filled in tweet.

You use it like this: 
`{{< tweetthis "this is a test tweet with hashtags" "satRdays" >}}`
The first argument, tweetthis calls the correct shortcode, the second argument is the main text and the third is the hashtags. The end results is a prefilled tweet that people can modify in their browser.