### PR TITLE
Remove ticket tailor from default on

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -151,7 +151,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
       # Supply this string as the value to `eid` above
 
   [params.tickettailor]
-    enable = true
+    enable = false
     title = "Register"
     bg = true
     eventviewid = "162430"


### PR DESCRIPTION
Recently ticket tailor have changed thier widget support, and also removed the 'test' event we relied on to populate the widget. The behaviour in local development is for this error to take over the whole screen, which is an irritation when we are trying to make this a friendly OS project.