### PR TITLE
Remove hugo-agency-theme from config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 baseurl = "https://eventtemplate.satrdays.org" # Change this to the base url after netlify deploy, e.g. "https://cardiff2019.satrdays.org/"
 languageCode = "en-us"
 title = "satRday"
-theme = ["hugo-satrdays-theme", "hugo-agency-theme"]
+theme = ["hugo-satrdays-theme"]
 
 # Enter your tracking code to enable Google Analytics
 googleAnalytics = ""


### PR DESCRIPTION
Follow up to #20. I couldn't build the site with `hugo serve` until I removed hugo-agency-theme from `config.toml`.

```
$ hugo version
Hugo Static Site Generator v0.72.0-8A7EF3CF/extended linux/amd64 BuildDate: 2020-05-31T12:14:23Z
```