### PR TITLE
Fix modalIDs

### DIFF
--- a/data/schedule/Talk01.toml
+++ b/data/schedule/Talk01.toml
@@ -1,6 +1,6 @@
-modalID= 1
 
 [talk_details]
+modalID = 1
 title = "First Talk"
 subtitle = "First Subtitle"
 date = 1970-01-01

--- a/data/schedule/Talk02.toml
+++ b/data/schedule/Talk02.toml
@@ -1,6 +1,6 @@
-modalID= 2
 
 [talk_details]
+modalID = 2
 title = "Second Talk"
 subtitle = "second Subtitle"
 date = 1970-01-01


### PR DESCRIPTION
The modalID's don't work properly if they aren't nested beneath `[talk_details]`.

I made my changes on top of the branch "main" since was the branch most recently committed to.